### PR TITLE
Change collect static command to GitHub deploy action

### DIFF
--- a/.github/workflows/liara.yaml
+++ b/.github/workflows/liara.yaml
@@ -19,3 +19,4 @@ jobs:
         run: |
           npm i -g @liara/cli@5
           liara deploy --app="$APP_NAME" --api-token="$LIARA_TOKEN" --port=8000 --no-app-logs
+          liara shell --app="$APP_NAME" --api-token="$LIARA_TOKEN" --command="python manage.py collectstatic --no-input"

--- a/liara.json
+++ b/liara.json
@@ -4,7 +4,7 @@
   "app": "toolbox",
   "django": {
     "pythonVersion": "3.10",
-    "collectStatic": true
+    "collectStatic": false
   },
   "disks": [
     {


### PR DESCRIPTION
In this hotfix, the `collectstatic` command will be executed from the `liara shell`. After successful deployment, this command will be executed.